### PR TITLE
Fixed Errors for Join projects in console

### DIFF
--- a/projectconnect/backend/project_flask/models/member.py
+++ b/projectconnect/backend/project_flask/models/member.py
@@ -57,8 +57,8 @@ class Member(User):
                     """, (username,))
                     
                     projects = cursor.fetchall()
-                    return {"status": "success", "projects": projects} if projects else {"status": "error", "message": "No joined projects found"}
+                return {"status": "success", "projects": projects or []}
         except Exception as e:
             print(f"Error fetching joined projects for member '{username}': {e}")
-            return {"error": f"Failed to fetch joined projects for member '{username}': {str(e)}"}
+            return {"status": "error", "message": f"Failed to fetch joined projects for member '{username}': {str(e)}"}
         

--- a/projectconnect/backend/project_flask/models/project.py
+++ b/projectconnect/backend/project_flask/models/project.py
@@ -299,10 +299,7 @@ class Project:
                     
                     projects = cursor.fetchall()  
                     
-                    if projects:
-                        return {"status": "success", "projects": projects}
-                    else:
-                        return {"status": "error", "message": "No projects found for the specified username"}
+                    return {"status": "success", "projects": projects or []}
         except Exception as e:
             print(f"Error fetching projects for creator '{creatorusername}': {e}")
             return {"error": f"Failed to fetch projects for creator '{creatorusername}': {str(e)}"}


### PR DESCRIPTION
Added Empty [] to allow for no error messages when the User either has no projects created or is not part of a project.
BUG: Join projects error in console #79
BUG: Errors in console when no created projects #78
